### PR TITLE
Integrate with gazebo_ros so there is no need to specify gazebo model path manually

### DIFF
--- a/destruction_scenarios/CMakeLists.txt
+++ b/destruction_scenarios/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(destruction_scenarios)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  gazebo_ros
+)
 
 catkin_package()

--- a/destruction_scenarios/package.xml
+++ b/destruction_scenarios/package.xml
@@ -19,4 +19,11 @@
   <license>GPL</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>gazebo_ros</build_depend>
+  <run_depend>gazebo_ros</run_depend>
+  
+  <export>
+    <gazebo_ros gazebo_media_path="${prefix}/worlds"/>
+    <gazebo_ros gazebo_model_path="${prefix}/worlds"/>
+  </export>
 </package>


### PR DESCRIPTION
This changeset adds the proper xml tags in package.xml so there is no need to perform manual setting of `GAZEBO_MODEL_PATH` anymore. Instead, the launch files can be used directly once they are part of a catkin workspace.
